### PR TITLE
Tutorial 2 Exercise: Implementing PID controller (only proportional term)

### DIFF
--- a/catkin_ws/src/auv_msgs/CMakeLists.txt
+++ b/catkin_ws/src/auv_msgs/CMakeLists.txt
@@ -15,7 +15,8 @@ find_package(catkin REQUIRED COMPONENTS
 ) 
 
 add_message_files(FILES
-	ThrusterCommand.msg
+	ThrusterIntensities.msg
+	ThrusterForces.msg
 )
 
 add_action_files(FILES

--- a/catkin_ws/src/auv_msgs/msg/ThrusterForces.msg
+++ b/catkin_ws/src/auv_msgs/msg/ThrusterForces.msg
@@ -1,0 +1,9 @@
+# force with which to spin each thruster (N)
+float64 SURGE_PORT
+float64 SURGE_STAR
+float64 SWAY_BOW
+float64 SWAY_STERN
+float64 HEAVE_BOW_PORT
+float64 HEAVE_BOW_STAR
+float64 HEAVE_STERN_STAR
+float64 HEAVE_STERN_PORT

--- a/catkin_ws/src/auv_msgs/msg/ThrusterIntensities.msg
+++ b/catkin_ws/src/auv_msgs/msg/ThrusterIntensities.msg
@@ -1,0 +1,12 @@
+#Thruster definitions
+uint8 SURGE_PORT=0
+uint8 SURGE_STAR=1
+uint8 SWAY_BOW=2
+uint8 SWAY_STERN=3
+uint8 HEAVE_BOW_PORT=4
+uint8 HEAVE_BOW_STAR=5
+uint8 HEAVE_STERN_STAR=6
+uint8 HEAVE_STERN_PORT=7
+
+# -1 full backwards, 1 full forwards, 0 stop
+float64[8] intensities

--- a/catkin_ws/src/controls/src/pid.py
+++ b/catkin_ws/src/controls/src/pid.py
@@ -8,23 +8,43 @@ from std_msgs.msg import Float64
 This node implements a PID controller (only proportional term)
 for the forward (x) direction of the robot
 
-Assume that the robot is able to move along the x axis, 
+We assume that the robot is able to move along the x axis, 
 and that it is always oriented forwards towards positive x 
 (so you don't need to bother with coordinate transformations)
 
-TO IMPLEMENT
----------------
-
-Subscribers:
-    1. to get setpoint from /setpoint_x topic (Float64)
-    2. to get current state from /state_x topic (float64)
-
-Publishers:
-    1. output the force (effort) with which the robot should 
-    move in the positive x direction on /surge topic
 '''
 
+pub = rospy.Publisher('/surge', Float64, queue_size=5)
+
+global current_setpoint
+current_setpoint = None
+
+def setCurrentSetpoint(setpt):
+	global current_setpoint
+	current_setpoint = setpt
+
+def calculateEffortToMoveToSetPoint(current_x):
+	global current_setpoint
+
+	# Want to check that current_setpoint has a value
+	if current_setpoint == None: return
+
+	# Find distance between the desired location and current location
+	# this is the error component Err
+	err = current_setpoint.data - current_x.data
+	
+	# kP, the proportional gain that we multiply by the error
+	proportional_gain = 0.2
+	
+	# Determine the effort (on x-axis, no rotation) needed for this 
+	# multiplying the distance between x and setpoint (err) by the 
+	# proportional gain value
+	effort = err * proportional_gain
+	
+	pub.publish(effort)
 
 if __name__ == '__main__':
     rospy.init_node('pid')
+    sub = rospy.Subscriber('/setpoint_x', Float64, setCurrentSetpoint)
+    sub = rospy.Subscriber('/state_x', Float64, calculateEffortToMoveToSetPoint)
     rospy.spin()

--- a/catkin_ws/src/propulsion/embedded/thrusters/thrusters.ino
+++ b/catkin_ws/src/propulsion/embedded/thrusters/thrusters.ino
@@ -1,6 +1,6 @@
 #include <ros.h>
 #include <Servo.h>
-#include <auv_msgs/ThrusterCommand.h>
+#include <auv_msgs/ThrusterIntensities.h>
 /* 
 NOTE: pins 2-9 were chosen instead of 0-7, since 
 pins 0 and 1 function differently.
@@ -22,14 +22,14 @@ pins 0 and 1 function differently.
 /* less verbose identifiers
 	Pin numbers [0-7] from ThusterCommand.msg
  */
-const uint8_t SRG_P 	= auv_msgs::ThrusterCommand::SURGE_PORT;
-const uint8_t SRG_S 	= auv_msgs::ThrusterCommand::SURGE_STAR;
-const uint8_t SWY_BW 	= auv_msgs::ThrusterCommand::SWAY_BOW;
-const uint8_t SWY_ST 	= auv_msgs::ThrusterCommand::SWAY_STERN;
-const uint8_t HVE_BW_P 	= auv_msgs::ThrusterCommand::HEAVE_BOW_PORT;
-const uint8_t HVE_BW_S 	= auv_msgs::ThrusterCommand::HEAVE_BOW_STAR;
-const uint8_t HVE_ST_S 	= auv_msgs::ThrusterCommand::HEAVE_STERN_STAR;
-const uint8_t HVE_ST_P 	= auv_msgs::ThrusterCommand::HEAVE_STERN_PORT;
+const uint8_t SRG_P 	= auv_msgs::ThrusterIntensities::SURGE_PORT;
+const uint8_t SRG_S 	= auv_msgs::ThrusterIntensities::SURGE_STAR;
+const uint8_t SWY_BW 	= auv_msgs::ThrusterIntensities::SWAY_BOW;
+const uint8_t SWY_ST 	= auv_msgs::ThrusterIntensities::SWAY_STERN;
+const uint8_t HVE_BW_P 	= auv_msgs::ThrusterIntensities::HEAVE_BOW_PORT;
+const uint8_t HVE_BW_S 	= auv_msgs::ThrusterIntensities::HEAVE_BOW_STAR;
+const uint8_t HVE_ST_S 	= auv_msgs::ThrusterIntensities::HEAVE_STERN_STAR;
+const uint8_t HVE_ST_P 	= auv_msgs::ThrusterIntensities::HEAVE_STERN_PORT;
 
 Servo thrusters[8];
 const float offCommand[] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0}; 
@@ -67,7 +67,7 @@ void thrustersOff(){
 	updateThrusters(offCommand);
 }
 
-void commandCb(const auv_msgs::ThrusterCommand& tc){
+void commandCb(const auv_msgs::ThrusterIntensities& tc){
 	const float* intensities = tc.intensities;
 	updateThrusters(intensities);
 }
@@ -88,7 +88,7 @@ void initThrusters(){
 
 
 ros::NodeHandle nh;
-ros::Subscriber<auv_msgs::ThrusterCommand> sub("propulsion/thruster_cmd", &commandCb);
+ros::Subscriber<auv_msgs::ThrusterIntensities> sub("propulsion/thruster_cmd", &commandCb);
 
 void setup() {
 	initThrusters();

--- a/catkin_ws/src/propulsion/launch/force_to_intensities.launch
+++ b/catkin_ws/src/propulsion/launch/force_to_intensities.launch
@@ -1,0 +1,3 @@
+<launch>
+	<node name="force_to_intensity" pkg="propulsion" type="force_to_intensity.py" respawn="true" />
+</launch>

--- a/catkin_ws/src/propulsion/launch/propulsion.launch
+++ b/catkin_ws/src/propulsion/launch/propulsion.launch
@@ -1,4 +1,5 @@
 <launch>
     <include file="$(find propulsion)/launch/thrust_mapper.launch" />
+    <include file="$(find propulsion)/launch/force_to_intensity.launch" />
     <include file="$(find propulsion)/launch/thrusters.launch" />
 </launch>

--- a/catkin_ws/src/propulsion/src/force_to_intensity.py
+++ b/catkin_ws/src/propulsion/src/force_to_intensity.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+import rospy
+from auv_msgs.msg import ThrusterForces, ThrusterIntensities
+
+# Force produced by T200 thruster at 16V (N)
+MAX_FWD_FORCE = 5.25*9.81
+MAX_BWD_FORCE = 4.1*9.81
+
+def force_to_intensity(force):
+	if force >= 0:
+		return force/MAX_FWD_FORCE
+	else:
+		return force/MAX_BKWD_FORCE
+		
+pub = rospy.Publisher('/propulsion/thruster_intensities', ThrusterIntensities, queue_size=5)
+
+# Functions or Relevant Code
+def forces_to_intensities_cb(forces_msg):
+	
+	# array message to publish
+	intens_arr = [None]*8
+	intens_arr[ThrusterIntensities.SURGE_PORT] = force_to_intensity(forces_msg.SURGE_PORT)
+	intens_arr[ThrusterIntensities.SURGE_STAR] = force_to_intensity(forces_msg.SURGE_STAR)
+	intens_arr[ThrusterIntensities.SWAY_BOW] = force_to_intensity(forces_msg.SWAY_BOW)
+	intens_arr[ThrusterIntensities.SWAY_STERN] = force_to_intensity(forces_msg.SWAY_STERN)
+	intens_arr[ThrusterIntensities.HEAVE_BOW_PORT] = force_to_intensity(forces_msg.HEAVE_BOW_PORT)
+	intens_arr[ThrusterIntensities.HEAVE_BOW_STAR] = force_to_intensity(forces_msg.HEAVE_BOW_STAR)
+	intens_arr[ThrusterIntensities.HEAVE_STERN_STAR] = force_to_intensity(forces_msg.HEAVE_STERN_STAR)
+	intens_arr[ThrusterIntensities.HEAVE_STERN_PORT] = force_to_intensity(forces_msg.HEAVE_STERN_PORT)
+	
+	intens_msg = ThrusterIntensities(intens_arr)
+	pub.publish(intens_msg)
+	
+if __name__ == '__main__':
+	rospy.init_node('force_to_intensity')
+	rospy.Subscriber('/propulsion/thruster_forces', ThrusterForces, forces_to_intensities_cb)
+	rospy.spin()

--- a/catkin_ws/src/propulsion/src/thrust_mapper.py
+++ b/catkin_ws/src/propulsion/src/thrust_mapper.py
@@ -3,14 +3,14 @@
 import numpy as np
 import rospy
 
-from auv_msgs.msg import ThrusterCommand
+from auv_msgs.msg import ThrusterForces
 from geometry_msgs.msg import Wrench
 
 d = 0.224 # m
 D_1 = 0.895 # m
 D_2 = 0.778 # m
 
-thrust_pub = rospy.Publisher('propulsion/thruster_cmd', ThrusterCommand, queue_size=5)
+thrust_pub = rospy.Publisher('propulsion/thruster_forces', ThrusterForces, queue_size=5)
 rospy.sleep(7.0) #TODO: FIX - wait for 7 sec to sync with arduino?
 
 T = np.matrix(


### PR DESCRIPTION
Hello, here's my PR for Tutorial 2. The first commit consists of the content of the tutorial itself, while the second commit is the code changes needed for the exercise. `pid.py` subscribes to two new topics, `/setpoint_x` and `/state_x`, wherein it will update the setpoint if necessary, and upon a new state being posted, it will publish the required effort to the topic `/surge` to get to that specified point.