### PR TITLE
Added other orientation calibration nodes and corresponding orientation PIDs

### DIFF
--- a/catkin_ws/src/calibration/launch/calibration.launch
+++ b/catkin_ws/src/calibration/launch/calibration.launch
@@ -1,5 +1,4 @@
 <launch>
 	<include file="$(find controls)/launch/controls.launch" />
 	<include file="$(find propulsion)/launch/propulsion.launch"/>
-	<include file="$(find calibration)/launch/heave_calibration.launch" />
 </launch>

--- a/catkin_ws/src/calibration/launch/heave_calibration.launch
+++ b/catkin_ws/src/calibration/launch/heave_calibration.launch
@@ -1,3 +1,0 @@
-<launch>
-	<node name="heave_calibration" pkg="calibration" type="heave_calibration.py" respawn="false" output="screen"/>
-</launch>

--- a/catkin_ws/src/calibration/launch/nominal_orientation_calibration.launch
+++ b/catkin_ws/src/calibration/launch/nominal_orientation_calibration.launch
@@ -1,0 +1,4 @@
+<launch>
+	<include file="$(find calibration)/launch/calibration.launch" />
+	<node name="nominal_orientation_calibration" pkg="calibration" type="nominal_orientation_calibration.py" respawn="false" output="screen"/>
+</launch>

--- a/catkin_ws/src/calibration/launch/pitched_orientation_calibration.launch
+++ b/catkin_ws/src/calibration/launch/pitched_orientation_calibration.launch
@@ -1,0 +1,4 @@
+<launch>
+	<include file="$(find calibration)/launch/calibration.launch" />
+	<node name="pitched_orientation_calibration" pkg="calibration" type="pitched_orientation_calibration.py" respawn="false" output="screen"/>
+</launch>

--- a/catkin_ws/src/calibration/launch/rolled_orientation_calibration.launch
+++ b/catkin_ws/src/calibration/launch/rolled_orientation_calibration.launch
@@ -1,0 +1,4 @@
+<launch>
+	<include file="$(find calibration)/launch/calibration.launch" />
+	<node name="rolled_orientation_calibration" pkg="calibration" type="rolled_orientation_calibration.py" respawn="false" output="screen"/>
+</launch>

--- a/catkin_ws/src/calibration/src/nominal_orientation_calibration.py
+++ b/catkin_ws/src/calibration/src/nominal_orientation_calibration.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+import rospy
+
+from std_msgs.msg import Float64
+
+pub_theta_x = rospy.Publisher('/theta_x_setpoint', Float64, queue_size=5, latch=True)
+pub_theta_y = rospy.Publisher('/theta_y_setpoint', Float64, queue_size=5, latch=True)
+pub_theta_z = rospy.Publisher('/theta_z_setpoint', Float64, queue_size=5, latch=True)
+
+pub_z = rospy.Publisher('/z_setpoint', Float64, queue_size=5, latch=True)
+
+if __name__ == '__main__':
+	rospy.init_node('nominal_orientation_calibration')
+	
+	# Move AUV down to submerge itself
+	pub_z.publish(-0.5)
+	
+	# Want no roll (theta-x = 0)
+	pub_theta_x.publish(0.0)
+	
+	# Want the AUV to level itself (such that theta_y = 0)
+	pub_theta_y.publish(0.0)
+	
+	# Want 0 degree yaw
+	pub_theta_z.publish(0.0)
+	
+	rospy.spin()

--- a/catkin_ws/src/calibration/src/pitched_orientation_calibration.py
+++ b/catkin_ws/src/calibration/src/pitched_orientation_calibration.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+import rospy
+import math
+
+from std_msgs.msg import Float64
+
+pub_theta_x = rospy.Publisher('/theta_x_setpoint', Float64, queue_size=5, latch=True)
+pub_theta_y = rospy.Publisher('/theta_y_setpoint', Float64, queue_size=5, latch=True)
+pub_theta_z = rospy.Publisher('/theta_z_setpoint', Float64, queue_size=5, latch=True)
+
+pub_z = rospy.Publisher('/z_setpoint', Float64, queue_size=5, latch=True)
+
+if __name__ == '__main__':
+	rospy.init_node('pitched_orientation_calibration')
+	
+	# Move AUV down to submerge itself
+	pub_z.publish(-0.5)
+		
+	# Want 0 degree roll
+	pub_theta_x.publish(0.0)
+	
+	# Want pitch to be 90 degrees 
+	pub_theta_y.publish(math.pi/2)
+	
+	# Want 0 degree yaw
+	pub_theta_z.publish(0.0)
+	
+	rospy.spin()

--- a/catkin_ws/src/calibration/src/rolled_orientation_calibration.py
+++ b/catkin_ws/src/calibration/src/rolled_orientation_calibration.py
@@ -1,18 +1,29 @@
 #!/usr/bin/env python3
 
 import rospy
+import math
 
 from std_msgs.msg import Float64
 
+pub_theta_x = rospy.Publisher('/theta_x_setpoint', Float64, queue_size=5, latch=True)
 pub_theta_y = rospy.Publisher('/theta_y_setpoint', Float64, queue_size=5, latch=True)
+pub_theta_z = rospy.Publisher('/theta_z_setpoint', Float64, queue_size=5, latch=True)
+
 pub_z = rospy.Publisher('/z_setpoint', Float64, queue_size=5, latch=True)
 
 if __name__ == '__main__':
-	rospy.init_node('heave_calibration')
+	rospy.init_node('rolled_orientation_calibration')
 	
 	# Move AUV down to submerge itself
 	pub_z.publish(-0.5)
 	
+	# Rolled up by 90 degrees
+	pub_theta_x.publish(math.pi/2)
+	
 	# Want the AUV to level itself (such that theta_y = 0)
 	pub_theta_y.publish(0.0)
+	
+	# Want 0 degree yaw
+	pub_theta_z.publish(0.0)
+	
 	rospy.spin()

--- a/catkin_ws/src/controls/launch/pid.launch
+++ b/catkin_ws/src/controls/launch/pid.launch
@@ -14,9 +14,24 @@
 		<param name="setpoint_topic" value="z_setpoint" />
 	</node>
 	
+	<node name="theta_x_pid" pkg="pid" type="controller" >
+		<param name="Kp" value="1.0" />
+		<param name="Ki" value="1.0" />
+		<param name="Kd" value="0.0" />
+		<param name="upper_limit" value="10" />
+		<param name="lower_limit" value="-10" />
+		<param name="windup_limit" value="10" />
+		<param name="max_loop_frequency" value="100.0" />
+		<param name="min_loop_frequency" value="100.0" />
+
+		<param name="topic_from_controller" value="/roll" />
+		<param name="topic_from_plant" value="/state_theta_x" />
+		<param name="setpoint_topic" value="theta_x_setpoint" />
+	</node>
+	
 	<node name="theta_y_pid" pkg="pid" type="controller" >
 		<param name="Kp" value="1.0" />
-		<param name="Ki" value="0.0" />
+		<param name="Ki" value="1.0" />
 		<param name="Kd" value="0.0" />
 		<param name="upper_limit" value="10" />
 		<param name="lower_limit" value="-10" />
@@ -27,5 +42,20 @@
 		<param name="topic_from_controller" value="/pitch" />
 		<param name="topic_from_plant" value="/state_theta_y" />
 		<param name="setpoint_topic" value="theta_y_setpoint" />
+	</node>
+	
+	<node name="theta_z_pid" pkg="pid" type="controller" >
+		<param name="Kp" value="1.0" />
+		<param name="Ki" value="1.0" />
+		<param name="Kd" value="0.0" />
+		<param name="upper_limit" value="10" />
+		<param name="lower_limit" value="-10" />
+		<param name="windup_limit" value="10" />
+		<param name="max_loop_frequency" value="100.0" />
+		<param name="min_loop_frequency" value="100.0" />
+
+		<param name="topic_from_controller" value="/yaw" />
+		<param name="topic_from_plant" value="/state_theta_z" />
+		<param name="setpoint_topic" value="theta_z_setpoint" />
 	</node>
 </launch>


### PR DESCRIPTION
- Renamed `heave_calibration` to `nominal_calibration`
- Added two more calibration nodes (one where pitch is 90 degrees and the other where roll is 90 degrees) and their corresponding launch files

Note: this assumes that `theta_x` corresponds to `roll`, `theta_y` corresponds to `pitch`, and `theta_z` corresponds to `yaw.` I wasn't 100% sure on these orientations but these were the ones that made the most sense to me.  

Also important to note the PID setpoint messages are also sent at the same time.