### PR TITLE
superimposer acts in robot's reference frame

### DIFF
--- a/thrust_mapper.py
+++ b/thrust_mapper.py
@@ -1,0 +1,20 @@
+def wrench_to_thrust(w):
+	
+	a = np.array(
+		[[w.force.x],
+		[w.force.y],
+		[w.force.z],
+		[w.torque.x],
+		[w.torque.y],
+		[w.torque.z]]] )
+	b = np.matmul(T_inv, a)
+	tc = ThrusterCommand([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]])
+	thust_pub.publish(tc)
+	return
+
+if __name__ == '__main__':
+	rospy.init_node('thrust_mapper')
+	sub = rospy.Subscriber('/effort', Wrench, wrench_to_thrust)
+	rospy.spin()
+
+


### PR DESCRIPTION
Removed reference frame translations from superimposer.py; assumed that inputs will already be in the robot's reference frame, so there's no need to transform them