### PR TITLE
update joystick mappings

### DIFF
--- a/catkin_ws/src/controls/config/joy_teleop.yaml
+++ b/catkin_ws/src/controls/config/joy_teleop.yaml
@@ -3,7 +3,7 @@ teleop:
     type: topic
     message_type: std_msgs/Float64
     topic_name: surge
-    deadman_buttons: [8]
+    deadman_buttons: [5]
     axis_mappings:
       -
         axis: 1
@@ -14,7 +14,7 @@ teleop:
     type: topic
     message_type: std_msgs/Float64
     topic_name: sway
-    deadman_buttons: [8]
+    deadman_buttons: [5]
     axis_mappings:
       -
         axis: 0
@@ -25,10 +25,10 @@ teleop:
     type: topic
     message_type: std_msgs/Float64
     topic_name: pitch
-    deadman_buttons: [8]
+    deadman_buttons: [5]
     axis_mappings:
       -
-        axis: 2
+        axis: 4
         target: data
         scale: -5
 
@@ -36,10 +36,27 @@ teleop:
     type: topic
     message_type: std_msgs/Float64
     topic_name: yaw
-    deadman_buttons: [8]
+    deadman_buttons: [5]
+    axis_mappings:
+      -
+        axis: 3
+        target: data
+        scale: -5
+
+roll:
+    type: topic
+    message_type: std_msgs/Float64
+    topic_name: roll
+    deadman_buttons: [5]
     axis_mappings:
       -
         axis: 2
         target: data
         scale: -5
 
+heave:
+    type: topic
+    message_type: std_msgs/Float64
+    topic_name: joy_heave
+    deadman_buttons: [5]
+    buttons: [1,0,5]

--- a/catkin_ws/src/controls/launch/joystick.launch
+++ b/catkin_ws/src/controls/launch/joystick.launch
@@ -1,5 +1,8 @@
 <launch>
-	<node name="ps3_joystick" pkg="joy" type="joy_node" />
+	<node name="ps3_joystick" pkg="joy" type="joy_node" >
+        <param name="dev" value="/dev/input/js0" />
+    </node>
     <rosparam file="$(find controls)/config/joy_teleop.yaml" command="load" />
     <node name="joy_teleop" pkg="joy_teleop" type="joy_teleop.py" />
+    <node name="joy_heave" pkg="controls" type="joy_heave.py" />
 </launch>

--- a/catkin_ws/src/controls/src/joy_heave.py
+++ b/catkin_ws/src/controls/src/joy_heave.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+import rospy
+from sensor_msgs.msg import Joy
+from std_msgs.msg import Float64
+
+
+
+positive_pub = rospy.Publisher('heave', Float64, queue_size=50)
+negative_pub = rospy.Publisher('heave', Float64, queue_size=50)
+heave_up = False
+heave_down = False
+
+
+def heave_cb(joy_msg):
+    if joy_msg.buttons[1] == 1 and joy_msg.buttons[5] == 1: #heave up
+        heave_up = True
+        heave_down = False
+    elif joy_msg.buttons[0] == 1 and joy_msg.buttons[5] == 1: #heave down
+        heave_up = False
+        heave_down = True
+    else: #neither button pressed
+        heave_up = False
+        heave_down = False
+        positive_pub.publish(Float64(0.0))
+        negative_pub.publish(Float64(0.0))
+
+    if heave_up:
+        positive_pub.publish(Float64(3.0))
+    elif heave_down:
+        negative_pub.publish(Float64(-3.0))
+
+rospy.Subscriber('joy', Joy, heave_cb )
+
+if __name__ == '__main__':
+    rospy.init_node('joy_heave')
+    rospy.Subscriber('joy', Joy, heave_cb )
+    rospy.spin() 
+    


### PR DESCRIPTION
Updated joystick mappings and created a node to increase/decrease heave. 
New mappings:
- deadman button: [5] (right bumper); must be held for joystick inputs to be registered
- sway: axis 0 (left joystick, horizontal axis)
- surge: axis 1 (left joystick, vertical axis)
- roll: axis 2 (left trigger)
- yaw: axis 3 (right joystick, horizontal axis)
- pitch: axis 4 (right joystick, vertical axis)
- heave, +z: button 1 (red circle)
- heave, -z: button 0 (blue X)