### PR TITLE
fix line endings issue with docker, fix submodule ignoring

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text eol=lf
+*.png binary
+*.pt binary

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,12 @@
 	path = catkin_ws/src/auv-sim-gazebo
 	url = https://github.com/mcgill-robotics/auv-sim-gazebo.git
 	ignore = all
+	update = merge
 	branch = noetic
 
 [submodule "catkin_ws/src/auv-sim-unity"]
 	path = catkin_ws/src/auv-sim-unity
 	url = https://github.com/mcgill-robotics/auv-sim-unity.git
 	ignore = all
+	update = merge
 	branch = noetic

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "catkin_ws/src/auv-sim-gazebo"]
 	path = catkin_ws/src/auv-sim-gazebo
 	url = https://github.com/mcgill-robotics/auv-sim-gazebo.git
-	ignore = dirty
+	ignore = all
+	branch = noetic
 
 [submodule "catkin_ws/src/auv-sim-unity"]
 	path = catkin_ws/src/auv-sim-unity
 	url = https://github.com/mcgill-robotics/auv-sim-unity.git
-	ignore = dirty
+	ignore = all
+	branch = noetic


### PR DESCRIPTION
Using gitattributes for end of line standards is bad and is better if windows users use the git config to set auto crlf to false. This removes unecessary file changes in pngs and other random file types (hopefully)

Also fix submodules to ignore properly now