### PR TITLE
made confidence an attribute of VisionObject class

### DIFF
--- a/catkin_ws/src/auv_msgs/msg/VisionObject.msg
+++ b/catkin_ws/src/auv_msgs/msg/VisionObject.msg
@@ -7,3 +7,5 @@ float64 z
 float64 theta_z
 #additional data field (for additional info on objects like lane marker second heading)
 float64 extra_field
+#confidence field
+float64 confidence

--- a/catkin_ws/src/vision/src/object_detection.py
+++ b/catkin_ws/src/vision/src/object_detection.py
@@ -71,7 +71,7 @@ def detect_on_image(raw_img, camera_id):
             if camera_id == 0: # DOWN CAM
                 if global_class_name == "Lane Marker":
                     detectionFrame.label = global_class_name
-                    confidence.append(conf)
+                    detectionFrame.confidence = conf
                     headings, center, debug_img = measureLaneMarker(img, bbox, debug_img)
                     if None in headings:
                         detectionFrame.extra_field = None
@@ -99,7 +99,7 @@ def detect_on_image(raw_img, camera_id):
                     
                 elif global_class_name == "Octagon Table": # OCTAGON TABLE
                     detectionFrame.label = global_class_name
-                    confidence.append(conf)
+                    detectionFrame.confidence = conf
                     pred_obj_x, pred_obj_y, pred_obj_z = getObjectPositionDownCam(bbox[0], bbox[1], img_h, img_w, octagon_table_top_z)
                     detectionFrame.x = pred_obj_x
                     detectionFrame.y = pred_obj_y
@@ -114,7 +114,7 @@ def detect_on_image(raw_img, camera_id):
             else: # FORWARD CAM
                 if global_class_name == "Lane Marker" or global_class_name == "Octagon Table": # LANE MARKER OR OCTAGON TABLE
                     detectionFrame.label = global_class_name
-                    confidence.append(conf)
+                    detectionFrame.confidence = conf
                     pred_obj_x, pred_obj_y, pred_obj_z = getObjectPositionFrontCam(bbox)
                     detectionFrame.x = pred_obj_x
                     detectionFrame.y = pred_obj_y
@@ -125,7 +125,7 @@ def detect_on_image(raw_img, camera_id):
                     detectionFrameArray.append(detectionFrame)
                 elif global_class_name == "Gate": # GATE
                     detectionFrame.label = global_class_name
-                    confidence.append(conf)
+                    detectionFrame.confidence = conf
                     theta_z = measureAngle(bbox)
                     pred_obj_x, pred_obj_y, pred_obj_z = getObjectPositionFrontCam(bbox)
                     detectionFrame.x = pred_obj_x
@@ -137,7 +137,7 @@ def detect_on_image(raw_img, camera_id):
                     detectionFrameArray.append(detectionFrame)
                 elif global_class_name == "Buoy": # BUOY
                     detectionFrame.label = global_class_name
-                    confidence.append(conf)
+                    detectionFrame.confidence = conf
                     theta_z = measureAngle(bbox)
                     pred_obj_x, pred_obj_y, pred_obj_z = getObjectPositionFrontCam(bbox)
                     detectionFrame.x = pred_obj_x
@@ -154,7 +154,7 @@ def detect_on_image(raw_img, camera_id):
                         detectionFrame.x = symbol_x
                         detectionFrame.y = symbol_y
                         detectionFrame.z = symbol_z
-                        confidence.append(confidence)
+                        detectionFrame.confidence = confidence
                         detectionFrame.theta_z = theta_z
                         detectionFrame.extra_field = None
 
@@ -168,7 +168,7 @@ def detect_on_image(raw_img, camera_id):
         obj.extra_field = obj.extra_field if obj.extra_field is not None else -1234.5
     
 
-    detectionFrameArray = cleanDetections(detectionFrameArray, confidence)
+    detectionFrameArray = cleanDetections(detectionFrameArray)
 
     if len(detectionFrameArray) > 0:
         #create object detection frame message and publish it

--- a/catkin_ws/src/vision/src/object_detection.py
+++ b/catkin_ws/src/vision/src/object_detection.py
@@ -37,13 +37,6 @@ def detect_on_image(raw_img, camera_id):
 
     #initialize empty array for object detection frame message
     detectionFrameArray = []
-    '''label = []
-    obj_x = []
-    obj_y = []
-    obj_z = []
-    obj_theta_z = []
-    extra_field = []'''
-    confidence = []
     img_h, img_w, _ = img.shape
     if camera_id == 1:
         #[COMP] change target symbol to match planner

--- a/catkin_ws/src/vision/src/object_detection_utils.py
+++ b/catkin_ws/src/vision/src/object_detection_utils.py
@@ -302,7 +302,7 @@ def analyzeBuoy(detections):
 
 
 #selects highest confidence detection from duplicates and ignores objects with no position measurement
-def cleanDetections(detectionFrameArray, confidences):
+def cleanDetections(detectionFrameArray):
     label_counts = {}
     selected_detections = []
 
@@ -310,9 +310,9 @@ def cleanDetections(detectionFrameArray, confidences):
         obj = detectionFrameArray[i]
         if None in [obj.x, obj.y, obj.z]: continue
         if label_counts.get(obj.label, 0) >= max_counts_per_label[obj.label]:
-            candidate_obj_conf = confidences[i]
-            min_conf_i = min(selected_detections, key=lambda x : confidences[x])
-            if confidences[min_conf_i] < candidate_obj_conf:
+            candidate_obj_conf = obj.confidence
+            min_conf_i = min(selected_detections, key=lambda x : detectionFrameArray[x].confidence)
+            if detectionFrameArray[min_conf_i].confidence < candidate_obj_conf:
                 selected_detections.remove(min_conf_i)
                 selected_detections.append(i)
         else:


### PR DESCRIPTION
## Related Issue(s)
  - Change "confidence" in vision detections to be an attribute of the VisionObject message instead of a python array (makes for cleaner code) #257

## Other Dependent PRs
 None

## Changes Made
- made confidence an attribute of VisionObject class
- changed code in object_detection.py and object_detection_utils.py to accommodate for the change

## Rationale/Other Solutions Considered
- to make the code more readable, I removed the confidence array and just used the existing DetectionFrameArray
- DetectionFrame.confidence is now the variable representing confidence of an object

## Tests Done
- Launched sim. No errors caused

## Optional Screen Recording
None

## Required Wiki Changes (if any)
- new field in VisionObject.msg but I don't think it requires a wiki change

## Required install_dependencies.sh Changes (if any)
- None

## Related Branches (other than one that will be merged)
- confidence-in-visionobject
