### PR TITLE
Add unit tests for euler_to_vector and find_intersection functions

### DIFF
--- a/catkin_ws/src/vision/launch/test/euler_to_vector.test
+++ b/catkin_ws/src/vision/launch/test/euler_to_vector.test
@@ -1,0 +1,7 @@
+<launch>
+	<include file="$(find sim)/launch/headless.launch"/>
+	<include file="$(find sim)/launch/sim.launch">
+		<arg name="vision" value="false" />
+	</include>
+	<test test-name="euler_to_vector" pkg="vision" type="euler_to_vector.py" time-limit="1500.0"/>
+</launch>

--- a/catkin_ws/src/vision/launch/test/find_intersection.test
+++ b/catkin_ws/src/vision/launch/test/find_intersection.test
@@ -1,0 +1,7 @@
+<launch>
+	<include file="$(find sim)/launch/headless.launch"/>
+	<include file="$(find sim)/launch/sim.launch">
+		<arg name="vision" value="false" />
+	</include>
+	<test test-name="find_intersection" pkg="vision" type="find_intersection_test.py" time-limit="1500.0"/>
+</launch>

--- a/catkin_ws/src/vision/src/euler_to_vector_test.py
+++ b/catkin_ws/src/vision/src/euler_to_vector_test.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+  
+import rospy
+import rostest
+import unittest
+import math
+import numpy as np
+from object_detection_utils import eulerToVectorDownCam
+
+class euler_to_vector_test(unittest.TestCase):
+    # When both angles are 0 degrees, the function should return a vector pointing straight down.
+    def test__ZeroDegrees(self):
+        vec = eulerToVectorDownCam(0, 0)
+        self.assertTrue(np.allclose(vec, np.array([0, 0, -1])))
+
+    # When both angles are 45 degrees, the function should return a vector pointing diagonally.
+    def test__45Degrees(self):
+        vec = eulerToVectorDownCam(45, 45)
+        expected_vec = np.array([-1, 1, -1]) / math.sqrt(3)
+        self.assertTrue(np.allclose(vec, expected_vec))
+
+    # When both angles are 90 degrees, the function should return a vector pointing straight up.
+    def test__90Degrees(self):
+        vec = eulerToVectorDownCam(90, 90)
+        expected_vec = np.array([-1, 1, 0]) / math.sqrt(2)
+        self.assertTrue(np.allclose(vec, expected_vec))
+
+    # When both angles are -45 degrees, the function should return a vector pointing diagonally in the opposite direction.
+    def test__NegativeDegrees(self):
+        vec = eulerToVectorDownCam(-45, -45)
+        expected_vec = np.array([1, -1, -1]) / math.sqrt(3)
+        self.assertTrue(np.allclose(vec, expected_vec))
+
+if __name__ == '__main__':
+    # rospy.init_node("euler_to_vector_test") - Already initialized in object_detection_utils.py
+    rostest.rosrun("vision", 'euler_to_vector_test', euler_to_vector_test)

--- a/catkin_ws/src/vision/src/find_intersection_test.py
+++ b/catkin_ws/src/vision/src/find_intersection_test.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+  
+import rospy
+import rostest
+import unittest
+import numpy as np
+from object_detection_utils import findIntersection
+
+class find_intersection_test(unittest.TestCase):
+    # When the vector points straight down, the function should return a point on the plane.
+    def test__VectorIntersectsPlane(self):
+        vector = np.array([1, 2, 3])
+        plane_z_pos = 6
+        result = findIntersection(vector, plane_z_pos)
+        expected_result = np.array([2, 4, 6])
+        np.testing.assert_array_equal(result, expected_result)
+
+    # When the vector is parallel to the plane, the function should return None.
+    def test__VectorParallelToPlane(self):
+        vector = np.array([1, 2, 0])
+        plane_z_pos = 6
+        result = findIntersection(vector, plane_z_pos)
+        self.assertIsNone(result)
+
+    # When the vector points away from the plane, the function should return None.
+    def test__VectorPointsAwayFromPlane(self):
+        vector = np.array([1, 2, -3])
+        plane_z_pos = 6
+        result = findIntersection(vector, plane_z_pos)
+        self.assertIsNone(result)
+
+if __name__ == '__main__':
+    # rospy.init_node("find_intersection_test") - Already initialized in object_detection_utils.py
+    rostest.rosrun("vision", 'find_intersection_test', find_intersection_test)


### PR DESCRIPTION
## Related Issue(s)
  -  #390

## Other Dependent PRs
 None

## Changes Made
- Created euler_to_vector.test, euler_to_vector_test.py, find_intersection.test, find_intersection_test.py for testing the respective functinos

## Rationale/Other Solutions Considered
- I just followed the conventions used in other testing files

## Tests Done
- I have performed the tests while the sim was running.
- Below are results

## Optional Screen Recording
find_intersection test:
![image](https://github.com/mcgill-robotics/AUV-2024/assets/71868004/5de3083b-a16e-4312-b45e-491b8a888606)
![image](https://github.com/mcgill-robotics/AUV-2024/assets/71868004/a8146ba7-35a4-4448-ab13-c235580b2562)
euler_to_vector test:
![image](https://github.com/mcgill-robotics/AUV-2024/assets/71868004/ae9214d1-93a3-4bf0-a0ca-9222047f8f59)
![image](https://github.com/mcgill-robotics/AUV-2024/assets/71868004/3aff98dd-20b5-4ecf-be1a-a9f100efbaed)


## Required Wiki Changes (if any)
- None

## Required install_dependencies.sh Changes (if any)
- None

## Related Branches (other than one that will be merged)
- tests_branch
- vision_enhance
