### PR TITLE
fixed cam bug, can now stream data from the dwn cam

### DIFF
--- a/catkin_ws/src/sensors/launch/stream-down-cam.launch
+++ b/catkin_ws/src/sensors/launch/stream-down-cam.launch
@@ -1,6 +1,6 @@
 <launch>
 	<node name="down_cam" pkg="usb_cam" type="usb_cam_node" output="screen">
-		<param name="video_device" value="/dev/downcam" />
+		<param name="video_device" value="/dev/down_cam" />
 		<param name="image_width" value="1280" />
 		<param name="image_height" value="720" />
 		<param name="pixel_format" value="yuyv" />


### PR DESCRIPTION
## Changes Made
- name of the device in the launch file was wrong (downcam --> down_cam). In the future, follow the naming conventions outlined in the udev rules
