### PR TITLE
New thruster mapping based on thruster test of May 2025

### DIFF
--- a/catkin_ws/src/propulsion/src/drytest.py
+++ b/catkin_ws/src/propulsion/src/drytest.py
@@ -6,6 +6,9 @@ from thrust_mapper_utils import *
 from geometry_msgs.msg import Wrench
 import keyboard
 
+MAX_FWD_FORCE = 4 * 9.81 # Max forward force (in Newtons) that all thruster can exert based on Thruster Test May 2025
+MAX_BKWD_FORCE = -2 * 9.81 # Max backward force (in Newtons) that all thruster can exert based on Thruster Test May 2025
+
 force_amt = 0.1  # 10%
 
 # TODO: update if necessary

--- a/catkin_ws/src/propulsion/src/thrust_mapper.py
+++ b/catkin_ws/src/propulsion/src/thrust_mapper.py
@@ -125,14 +125,14 @@ class ThrusterMapper:
         Applies individual limits to prevent overcurrent.
         """
         pwm_arr = [None] * 8
-        pwm_arr[ThrusterMicroseconds.BACK_LEFT] = force_to_pwm_thruster8(forces_msg.BACK_LEFT * thruster_mount_dirs[ThrusterMicroseconds.BACK_LEFT])
-        pwm_arr[ThrusterMicroseconds.HEAVE_BACK_LEFT] = force_to_pwm_thruster7(forces_msg.HEAVE_BACK_LEFT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_BACK_LEFT])
-        pwm_arr[ThrusterMicroseconds.HEAVE_FRONT_LEFT] = force_to_pwm_thruster6(forces_msg.HEAVE_FRONT_LEFT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_FRONT_LEFT])
-        pwm_arr[ThrusterMicroseconds.FRONT_LEFT] = force_to_pwm_thruster5(forces_msg.FRONT_LEFT * thruster_mount_dirs[ThrusterMicroseconds.FRONT_LEFT])
-        pwm_arr[ThrusterMicroseconds.FRONT_RIGHT] = force_to_pwm_thruster4(forces_msg.FRONT_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.FRONT_RIGHT])
-        pwm_arr[ThrusterMicroseconds.HEAVE_FRONT_RIGHT] = force_to_pwm_thruster3(forces_msg.HEAVE_FRONT_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_FRONT_RIGHT])
-        pwm_arr[ThrusterMicroseconds.HEAVE_BACK_RIGHT] = force_to_pwm_thruster2(forces_msg.HEAVE_BACK_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_BACK_RIGHT])
-        pwm_arr[ThrusterMicroseconds.BACK_RIGHT] = force_to_pwm_thruster1(forces_msg.BACK_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.BACK_RIGHT])
+        pwm_arr[ThrusterMicroseconds.BACK_LEFT] = force_to_pwm_thruster1(forces_msg.BACK_LEFT * thruster_mount_dirs[ThrusterMicroseconds.BACK_LEFT])
+        pwm_arr[ThrusterMicroseconds.HEAVE_BACK_LEFT] = force_to_pwm_thruster2(forces_msg.HEAVE_BACK_LEFT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_BACK_LEFT])
+        pwm_arr[ThrusterMicroseconds.HEAVE_FRONT_LEFT] = force_to_pwm_thruster3(forces_msg.HEAVE_FRONT_LEFT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_FRONT_LEFT])
+        pwm_arr[ThrusterMicroseconds.FRONT_LEFT] = force_to_pwm_thruster4(forces_msg.FRONT_LEFT * thruster_mount_dirs[ThrusterMicroseconds.FRONT_LEFT])
+        pwm_arr[ThrusterMicroseconds.FRONT_RIGHT] = force_to_pwm_thruster5(forces_msg.FRONT_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.FRONT_RIGHT])
+        pwm_arr[ThrusterMicroseconds.HEAVE_FRONT_RIGHT] = force_to_pwm_thruster6(forces_msg.HEAVE_FRONT_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_FRONT_RIGHT])
+        pwm_arr[ThrusterMicroseconds.HEAVE_BACK_RIGHT] = force_to_pwm_thruster7(forces_msg.HEAVE_BACK_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_BACK_RIGHT])
+        pwm_arr[ThrusterMicroseconds.BACK_RIGHT] = force_to_pwm_thruster8(forces_msg.BACK_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.BACK_RIGHT])
     
         # Retrieve PWM limits from parameters
         thruster_lower_limit = rospy.get_param("thruster_PWM_lower_limit")

--- a/catkin_ws/src/propulsion/src/thrust_mapper.py
+++ b/catkin_ws/src/propulsion/src/thrust_mapper.py
@@ -125,14 +125,14 @@ class ThrusterMapper:
         Applies individual limits to prevent overcurrent.
         """
         pwm_arr = [None] * 8
-        pwm_arr[ThrusterMicroseconds.BACK_LEFT] = force_to_pwm_thruster1(forces_msg.BACK_LEFT * thruster_mount_dirs[ThrusterMicroseconds.BACK_LEFT])
-        pwm_arr[ThrusterMicroseconds.HEAVE_BACK_LEFT] = force_to_pwm_thruster2(forces_msg.HEAVE_BACK_LEFT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_BACK_LEFT])
-        pwm_arr[ThrusterMicroseconds.HEAVE_FRONT_LEFT] = force_to_pwm_thruster3(forces_msg.HEAVE_FRONT_LEFT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_FRONT_LEFT])
-        pwm_arr[ThrusterMicroseconds.FRONT_LEFT] = force_to_pwm_thruster4(forces_msg.FRONT_LEFT * thruster_mount_dirs[ThrusterMicroseconds.FRONT_LEFT])
-        pwm_arr[ThrusterMicroseconds.FRONT_RIGHT] = force_to_pwm_thruster5(forces_msg.FRONT_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.FRONT_RIGHT])
-        pwm_arr[ThrusterMicroseconds.HEAVE_FRONT_RIGHT] = force_to_pwm_thruster6(forces_msg.HEAVE_FRONT_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_FRONT_RIGHT])
-        pwm_arr[ThrusterMicroseconds.HEAVE_BACK_RIGHT] = force_to_pwm_thruster7(forces_msg.HEAVE_BACK_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_BACK_RIGHT])
-        pwm_arr[ThrusterMicroseconds.BACK_RIGHT] = force_to_pwm_thruster8(forces_msg.BACK_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.BACK_RIGHT])
+        pwm_arr[ThrusterMicroseconds.BACK_LEFT] = force_to_pwm_thruster8(forces_msg.BACK_LEFT * thruster_mount_dirs[ThrusterMicroseconds.BACK_LEFT])
+        pwm_arr[ThrusterMicroseconds.HEAVE_BACK_LEFT] = force_to_pwm_thruster7(forces_msg.HEAVE_BACK_LEFT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_BACK_LEFT])
+        pwm_arr[ThrusterMicroseconds.HEAVE_FRONT_LEFT] = force_to_pwm_thruster6(forces_msg.HEAVE_FRONT_LEFT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_FRONT_LEFT])
+        pwm_arr[ThrusterMicroseconds.FRONT_LEFT] = force_to_pwm_thruster5(forces_msg.FRONT_LEFT * thruster_mount_dirs[ThrusterMicroseconds.FRONT_LEFT])
+        pwm_arr[ThrusterMicroseconds.FRONT_RIGHT] = force_to_pwm_thruster4(forces_msg.FRONT_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.FRONT_RIGHT])
+        pwm_arr[ThrusterMicroseconds.HEAVE_FRONT_RIGHT] = force_to_pwm_thruster3(forces_msg.HEAVE_FRONT_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_FRONT_RIGHT])
+        pwm_arr[ThrusterMicroseconds.HEAVE_BACK_RIGHT] = force_to_pwm_thruster2(forces_msg.HEAVE_BACK_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_BACK_RIGHT])
+        pwm_arr[ThrusterMicroseconds.BACK_RIGHT] = force_to_pwm_thruster1(forces_msg.BACK_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.BACK_RIGHT])
     
         # Retrieve PWM limits from parameters
         thruster_lower_limit = rospy.get_param("thruster_PWM_lower_limit")

--- a/catkin_ws/src/propulsion/src/thrust_mapper.py
+++ b/catkin_ws/src/propulsion/src/thrust_mapper.py
@@ -6,7 +6,17 @@ and then converts the forces to PWM signals and publishes them.
 
 import numpy as np
 import rospy
-from thrust_mapper_utils import *  # Assumes force_to_pwm, thruster_mount_dirs, etc. are defined here.
+from thrust_mapper_utils import (
+    thruster_mount_dirs,
+    force_to_pwm_thruster1,
+    force_to_pwm_thruster2,
+    force_to_pwm_thruster3,
+    force_to_pwm_thruster4,
+    force_to_pwm_thruster5,
+    force_to_pwm_thruster6,
+    force_to_pwm_thruster7,
+    force_to_pwm_thruster8,
+)  # Assumes force_to_pwm, thruster_mount_dirs, etc. are defined here.
 from auv_msgs.msg import ThrusterForces, ThrusterMicroseconds
 from geometry_msgs.msg import Wrench, Vector3
 from nav_msgs.msg import Odometry
@@ -115,14 +125,14 @@ class ThrusterMapper:
         Applies individual limits to prevent overcurrent.
         """
         pwm_arr = [None] * 8
-        pwm_arr[ThrusterMicroseconds.BACK_LEFT] = force_to_pwm(forces_msg.BACK_LEFT * thruster_mount_dirs[ThrusterMicroseconds.BACK_LEFT])
-        pwm_arr[ThrusterMicroseconds.HEAVE_BACK_LEFT] = force_to_pwm(forces_msg.HEAVE_BACK_LEFT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_BACK_LEFT])
-        pwm_arr[ThrusterMicroseconds.HEAVE_FRONT_LEFT] = force_to_pwm(forces_msg.HEAVE_FRONT_LEFT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_FRONT_LEFT])
-        pwm_arr[ThrusterMicroseconds.FRONT_LEFT] = force_to_pwm(forces_msg.FRONT_LEFT * thruster_mount_dirs[ThrusterMicroseconds.FRONT_LEFT])
-        pwm_arr[ThrusterMicroseconds.FRONT_RIGHT] = force_to_pwm(forces_msg.FRONT_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.FRONT_RIGHT])
-        pwm_arr[ThrusterMicroseconds.HEAVE_FRONT_RIGHT] = force_to_pwm(forces_msg.HEAVE_FRONT_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_FRONT_RIGHT])
-        pwm_arr[ThrusterMicroseconds.HEAVE_BACK_RIGHT] = force_to_pwm(forces_msg.HEAVE_BACK_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_BACK_RIGHT])
-        pwm_arr[ThrusterMicroseconds.BACK_RIGHT] = force_to_pwm(forces_msg.BACK_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.BACK_RIGHT])
+        pwm_arr[ThrusterMicroseconds.BACK_LEFT] = force_to_pwm_thruster8(forces_msg.BACK_LEFT * thruster_mount_dirs[ThrusterMicroseconds.BACK_LEFT])
+        pwm_arr[ThrusterMicroseconds.HEAVE_BACK_LEFT] = force_to_pwm_thruster7(forces_msg.HEAVE_BACK_LEFT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_BACK_LEFT])
+        pwm_arr[ThrusterMicroseconds.HEAVE_FRONT_LEFT] = force_to_pwm_thruster6(forces_msg.HEAVE_FRONT_LEFT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_FRONT_LEFT])
+        pwm_arr[ThrusterMicroseconds.FRONT_LEFT] = force_to_pwm_thruster5(forces_msg.FRONT_LEFT * thruster_mount_dirs[ThrusterMicroseconds.FRONT_LEFT])
+        pwm_arr[ThrusterMicroseconds.FRONT_RIGHT] = force_to_pwm_thruster4(forces_msg.FRONT_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.FRONT_RIGHT])
+        pwm_arr[ThrusterMicroseconds.HEAVE_FRONT_RIGHT] = force_to_pwm_thruster3(forces_msg.HEAVE_FRONT_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_FRONT_RIGHT])
+        pwm_arr[ThrusterMicroseconds.HEAVE_BACK_RIGHT] = force_to_pwm_thruster2(forces_msg.HEAVE_BACK_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_BACK_RIGHT])
+        pwm_arr[ThrusterMicroseconds.BACK_RIGHT] = force_to_pwm_thruster1(forces_msg.BACK_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.BACK_RIGHT])
     
         # Retrieve PWM limits from parameters
         thruster_lower_limit = rospy.get_param("thruster_PWM_lower_limit")

--- a/catkin_ws/src/propulsion/src/thrust_mapper.py
+++ b/catkin_ws/src/propulsion/src/thrust_mapper.py
@@ -6,17 +6,7 @@ and then converts the forces to PWM signals and publishes them.
 
 import numpy as np
 import rospy
-from thrust_mapper_utils import (
-    thruster_mount_dirs,
-    force_to_pwm_thruster1,
-    force_to_pwm_thruster2,
-    force_to_pwm_thruster3,
-    force_to_pwm_thruster4,
-    force_to_pwm_thruster5,
-    force_to_pwm_thruster6,
-    force_to_pwm_thruster7,
-    force_to_pwm_thruster8,
-)  # Assumes force_to_pwm, thruster_mount_dirs, etc. are defined here.
+from thrust_mapper_utils import thruster_mount_dirs, force_to_pwm_thruster  # Assumes force_to_pwm, thruster_mount_dirs, etc. are defined here.
 from auv_msgs.msg import ThrusterForces, ThrusterMicroseconds
 from geometry_msgs.msg import Wrench, Vector3
 from nav_msgs.msg import Odometry
@@ -125,14 +115,14 @@ class ThrusterMapper:
         Applies individual limits to prevent overcurrent.
         """
         pwm_arr = [None] * 8
-        pwm_arr[ThrusterMicroseconds.BACK_LEFT] = force_to_pwm_thruster8(forces_msg.BACK_LEFT * thruster_mount_dirs[ThrusterMicroseconds.BACK_LEFT])
-        pwm_arr[ThrusterMicroseconds.HEAVE_BACK_LEFT] = force_to_pwm_thruster7(forces_msg.HEAVE_BACK_LEFT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_BACK_LEFT])
-        pwm_arr[ThrusterMicroseconds.HEAVE_FRONT_LEFT] = force_to_pwm_thruster6(forces_msg.HEAVE_FRONT_LEFT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_FRONT_LEFT])
-        pwm_arr[ThrusterMicroseconds.FRONT_LEFT] = force_to_pwm_thruster5(forces_msg.FRONT_LEFT * thruster_mount_dirs[ThrusterMicroseconds.FRONT_LEFT])
-        pwm_arr[ThrusterMicroseconds.FRONT_RIGHT] = force_to_pwm_thruster4(forces_msg.FRONT_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.FRONT_RIGHT])
-        pwm_arr[ThrusterMicroseconds.HEAVE_FRONT_RIGHT] = force_to_pwm_thruster3(forces_msg.HEAVE_FRONT_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_FRONT_RIGHT])
-        pwm_arr[ThrusterMicroseconds.HEAVE_BACK_RIGHT] = force_to_pwm_thruster2(forces_msg.HEAVE_BACK_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_BACK_RIGHT])
-        pwm_arr[ThrusterMicroseconds.BACK_RIGHT] = force_to_pwm_thruster1(forces_msg.BACK_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.BACK_RIGHT])
+        pwm_arr[ThrusterMicroseconds.BACK_LEFT] = force_to_pwm_thruster(8,forces_msg.BACK_LEFT * thruster_mount_dirs[ThrusterMicroseconds.BACK_LEFT])
+        pwm_arr[ThrusterMicroseconds.HEAVE_BACK_LEFT] = force_to_pwm_thruster(7,forces_msg.HEAVE_BACK_LEFT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_BACK_LEFT])
+        pwm_arr[ThrusterMicroseconds.HEAVE_FRONT_LEFT] = force_to_pwm_thruster(6,forces_msg.HEAVE_FRONT_LEFT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_FRONT_LEFT])
+        pwm_arr[ThrusterMicroseconds.FRONT_LEFT] = force_to_pwm_thruster(5,forces_msg.FRONT_LEFT * thruster_mount_dirs[ThrusterMicroseconds.FRONT_LEFT])
+        pwm_arr[ThrusterMicroseconds.FRONT_RIGHT] = force_to_pwm_thruster(4,forces_msg.FRONT_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.FRONT_RIGHT])
+        pwm_arr[ThrusterMicroseconds.HEAVE_FRONT_RIGHT] = force_to_pwm_thruster(3,forces_msg.HEAVE_FRONT_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_FRONT_RIGHT])
+        pwm_arr[ThrusterMicroseconds.HEAVE_BACK_RIGHT] = force_to_pwm_thruster(2,forces_msg.HEAVE_BACK_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.HEAVE_BACK_RIGHT])
+        pwm_arr[ThrusterMicroseconds.BACK_RIGHT] = force_to_pwm_thruster(1,forces_msg.BACK_RIGHT * thruster_mount_dirs[ThrusterMicroseconds.BACK_RIGHT])
     
         # Retrieve PWM limits from parameters
         thruster_lower_limit = rospy.get_param("thruster_PWM_lower_limit")

--- a/catkin_ws/src/propulsion/src/thrust_mapper_utils.py
+++ b/catkin_ws/src/propulsion/src/thrust_mapper_utils.py
@@ -1,7 +1,52 @@
 import numpy as np
-#Thrusters, like the Blue Robotics T200, don’t have a perfectly linear response near zero force.
-#Linear transition region around zero force (Newtons)
-#Creates a smooth transition around zero force to avoid abrupt changes in PWM.
+
+# Thrusters like the Blue Robotics T200 do not have a perfectly linear thrust response near 0 N.
+# To avoid abrupt changes and motor jitter near zero thrust, a linear deadband smoothing is applied
+# in the small force region (|force| < deadband_eps). Outside this region, a 5th-order polynomial 
+# fitted to experimental data is used to convert thrust (N) to PWM (μs).
+
+# Deadband region around 0 N where smoothing is applied
+deadband_eps = 0.5
+
+# Polynomial coefficients for each thruster.
+# Each tuple contains (coeffs_left, coeffs_right), where:
+# - coeffs_left corresponds to negative thrust (force < -deadband_eps)
+# - coeffs_right corresponds to positive thrust (force > +deadband_eps)
+# The polynomials were fit using least-squares to May 2025 thruster test data.
+thruster_poly_coeffs = [
+    (
+        [1.0230567551000761e-05, 0.00102996961393584, 0.040389999005431505, 0.7860223131995762, 16.77703700452621, 1458.4801287000814],
+        [3.430757828456944e-06, -0.0004931410796589675, 0.026547762979844677, -0.6681700673886003, 15.361505309013667, 1532.2050959044316]
+    ),
+    (
+        [1.9792619863856807e-05, 0.00430568657152564, 0.16552600527321884, 2.005302506063938, 21.44799478063138, 1469.2876938929282],
+        [2.7590747726334654e-06, -0.0004267788232113865, 0.023788005495560777, -0.6053581191075251, 15.257178074416181, 1537.8143209940818]
+    ),
+    (
+        [0.00015828221751606117, 0.01158034626673705, 0.29139761923839835, 2.9414234100262417, 23.829243182617976, 1462.4806630341138],
+        [1.7707706911964165e-06, -0.00027076966193783096, 0.015275019271750026, -0.423532293350616, 13.60742808725115, 1537.3243900034613]
+    ),
+    (
+        [-1.1552965779022153e-05, 0.00038064670238558356, 0.06404572005694033, 1.6789593308233672, 26.85675098723853, 1489.744988765967],
+        [4.28729616014896e-06, -0.0005682519968556897, 0.02886925945271591, -0.7292412806746723, 17.22831131585594, 1532.5325493925116]
+    ),
+    (
+        [-6.941580671470798e-06, -0.00058557986492076, -0.013961189254281707, -0.0002720187161500033, 12.236038684182764, 1448.4552329804822],
+        [8.932847739553046e-07, -0.00019474823917039024, 0.013292476455512672, -0.39827137223089093, 13.002323887488586, 1535.342515302347]
+    ),
+    (
+        [1.5816032862031332e-05, 0.0012422185608465996, 0.038226378488502424, 0.6168147468496009, 15.760260299367387, 1456.195377454675],
+        [2.7107832175712445e-06, -0.00037330147281785505, 0.019542179140516265, -0.4943442917222498, 14.201154149884227, 1534.225644742625]
+    ),
+    (
+        [4.7698603291927485e-06, 0.0005523684514175677, 0.025124707629480242, 0.5688673391241492, 16.13382387002397, 1464.9715537145275],
+        [-9.267882571985216e-07, 4.954572425873791e-05, 0.0016201687947042655, -0.15277570672157192, 10.893237417742466, 1544.2819910395674]
+    ),
+    (
+        [1.969990453701789e-05, 0.0018732855138689026, 0.0669614466686662, 1.1258357561487122, 18.729839818258526, 1465.5025109239948],
+        [4.747498741718638e-06, -0.0005519151129485432, 0.0243819736986421, -0.5313334295643649, 13.750987401737758, 1533.5188424837772]
+    ),
+]
 
 thruster_mount_dirs = [ #rep physical orientation of thrusters
     1,   # BACK_LEFT (CCW)
@@ -16,26 +61,24 @@ thruster_mount_dirs = [ #rep physical orientation of thrusters
 #1 is forward, -1 is backward, 0.5 is half thrust in specific direction
 #If force is exactly zero, returns 1500 μs (neutral signal, no movement).
 
-def force_to_pwm_thruster1(force):
-    '''Converts a desired thrust force (in Newtons) into a PWM signal (in microseconds)
-    for Thruster 1 using a two-sided 5th-order polynomial fit and linear smoothing 
-    in the deadband region. Coefficients of the polynomials for all 8 thrusters were made
-    to fit the the Thruster Test Data of May 2025. 
 
-    - For forces above +0.5 N, a polynomial fit for positive forces is used.
-    - For forces below -0.5 N, a polynomial fit for negative forces is used.
-    - For small forces within ±0.5 N, the function linearly interpolates 
-      between 1500 µs and the polynomial curves to ensure smooth transitions 
-      and prevent jitter near zero thrust.
-    
-    The output PWM is clipped to remain within [1100, 1900] µs, which matches 
-    our ESC input limits.'''
-    
-    deadband_eps = 0.5
-    coeffs_left = [1.0230567551000761e-05, 0.00102996961393584, 0.040389999005431505, 0.7860223131995762, 16.77703700452621, 1458.4801287000814] 
-    coeffs_right = [3.430757828456944e-06, -0.0004931410796589675, 0.026547762979844677, -0.6681700673886003, 15.361505309013667, 1532.2050959044316]  
 
+def force_to_pwm(force, coeffs_left, coeffs_right):
+    """
+    Converts a desired thrust force (in Newtons) into a PWM signal (in microseconds) using:
+    - A two-sided 5th-order polynomial for forces |force| > deadband_eps
+    - Linear interpolation for forces within the deadband region (|force| ≤ deadband_eps)
+
+    Parameters:
+        force         : float, desired thrust force in Newtons
+        coeffs_left   : list of float, polynomial coefficients for negative forces
+        coeffs_right  : list of float, polynomial coefficients for positive forces
+
+    Returns:
+        int: PWM signal in microseconds, clipped to [1100, 1900] µs (ESC input range)
+    """
     if abs(force) <= deadband_eps:
+        # Linear interpolation within deadband to ensure smooth transition
         pwm_pos_eps = np.polyval(coeffs_right, deadband_eps)
         pwm_neg_eps = np.polyval(coeffs_left, -deadband_eps)
         if force >= 0:
@@ -49,141 +92,16 @@ def force_to_pwm_thruster1(force):
 
     return int(np.clip(pwm, 1100, 1900))
 
-def force_to_pwm_thruster2(force):
-    deadband_eps = 0.5
-    coeffs_left = [1.9792619863856807e-05, 0.00430568657152564, 0.16552600527321884, 2.005302506063938, 21.44799478063138, 1469.2876938929282]
-    coeffs_right = [2.7590747726334654e-06, -0.0004267788232113865, 0.023788005495560777, -0.6053581191075251, 15.257178074416181, 1537.8143209940818]
+def force_to_pwm_thruster(thruster_index, force):
+    """
+    Dispatches force-to-PWM conversion for a specific thruster based on its index.
 
-    if abs(force) <= deadband_eps:
-        pwm_pos_eps = np.polyval(coeffs_right, deadband_eps)
-        pwm_neg_eps = np.polyval(coeffs_left, -deadband_eps)
-        if force >= 0:
-            pwm = 1500 + (force / deadband_eps) * (pwm_pos_eps - 1500)
-        else:
-            pwm = 1500 + (force / deadband_eps) * (1500 - pwm_neg_eps)
-    elif force < -deadband_eps:
-        pwm = np.polyval(coeffs_left, force)
-    else:
-        pwm = np.polyval(coeffs_right, force)
+    Parameters:
+        thruster_index : int, index from 1 to 8 representing the 8 thrusters
+        force          : float, desired thrust force in Newtons
 
-    return int(np.clip(pwm, 1100, 1900))
-
-
-def force_to_pwm_thruster3(force):
-    deadband_eps = 0.5
-    coeffs_left = [0.00015828221751606117, 0.01158034626673705, 0.29139761923839835, 2.9414234100262417, 23.829243182617976, 1462.4806630341138] 
-    coeffs_right =  [1.7707706911964165e-06, -0.00027076966193783096, 0.015275019271750026, -0.423532293350616, 13.60742808725115, 1537.3243900034613] 
-
-    if abs(force) <= deadband_eps:
-        pwm_pos_eps = np.polyval(coeffs_right, deadband_eps)
-        pwm_neg_eps = np.polyval(coeffs_left, -deadband_eps)
-        if force >= 0:
-            pwm = 1500 + (force / deadband_eps) * (pwm_pos_eps - 1500)
-        else:
-            pwm = 1500 + (force / deadband_eps) * (1500 - pwm_neg_eps)
-    elif force < -deadband_eps:
-        pwm = np.polyval(coeffs_left, force)
-    else:
-        pwm = np.polyval(coeffs_right, force)
-
-    return int(np.clip(pwm, 1100, 1900))
-
-
-def force_to_pwm_thruster4(force):
-    deadband_eps = 0.5
-    coeffs_left = [-1.1552965779022153e-05, 0.00038064670238558356, 0.06404572005694033, 1.6789593308233672, 26.85675098723853, 1489.744988765967] 
-    coeffs_right = [4.28729616014896e-06, -0.0005682519968556897, 0.02886925945271591, -0.7292412806746723, 17.22831131585594, 1532.5325493925116]
-
-    if abs(force) <= deadband_eps:
-        pwm_pos_eps = np.polyval(coeffs_right, deadband_eps)
-        pwm_neg_eps = np.polyval(coeffs_left, -deadband_eps)
-        if force >= 0:
-            pwm = 1500 + (force / deadband_eps) * (pwm_pos_eps - 1500)
-        else:
-            pwm = 1500 + (force / deadband_eps) * (1500 - pwm_neg_eps)
-    elif force < -deadband_eps:
-        pwm = np.polyval(coeffs_left, force)
-    else:
-        pwm = np.polyval(coeffs_right, force)
-
-    return int(np.clip(pwm, 1100, 1900))
-
-
-def force_to_pwm_thruster5(force):
-    deadband_eps = 0.5
-    coeffs_left = [-6.941580671470798e-06, -0.00058557986492076, -0.013961189254281707, -0.0002720187161500033, 12.236038684182764, 1448.4552329804822]
-    coeffs_right = [8.932847739553046e-07, -0.00019474823917039024, 0.013292476455512672, -0.39827137223089093, 13.002323887488586, 1535.342515302347]
-
-    if abs(force) <= deadband_eps:
-        pwm_pos_eps = np.polyval(coeffs_right, deadband_eps)
-        pwm_neg_eps = np.polyval(coeffs_left, -deadband_eps)
-        if force >= 0:
-            pwm = 1500 + (force / deadband_eps) * (pwm_pos_eps - 1500)
-        else:
-            pwm = 1500 + (force / deadband_eps) * (1500 - pwm_neg_eps)
-    elif force < -deadband_eps:
-        pwm = np.polyval(coeffs_left, force)
-    else:
-        pwm = np.polyval(coeffs_right, force)
-
-    return int(np.clip(pwm, 1100, 1900))
-
-
-
-def force_to_pwm_thruster6(force):
-    deadband_eps = 0.5
-    coeffs_left = [1.5816032862031332e-05, 0.0012422185608465996, 0.038226378488502424, 0.6168147468496009, 15.760260299367387, 1456.195377454675] 
-    coeffs_right = [2.7107832175712445e-06, -0.00037330147281785505, 0.019542179140516265, -0.4943442917222498, 14.201154149884227, 1534.225644742625]
-
-    if abs(force) <= deadband_eps:
-        pwm_pos_eps = np.polyval(coeffs_right, deadband_eps)
-        pwm_neg_eps = np.polyval(coeffs_left, -deadband_eps)
-        if force >= 0:
-            pwm = 1500 + (force / deadband_eps) * (pwm_pos_eps - 1500)
-        else:
-            pwm = 1500 + (force / deadband_eps) * (1500 - pwm_neg_eps)
-    elif force < -deadband_eps:
-        pwm = np.polyval(coeffs_left, force)
-    else:
-        pwm = np.polyval(coeffs_right, force)
-
-    return int(np.clip(pwm, 1100, 1900))
-
-
-def force_to_pwm_thruster7(force):
-    deadband_eps = 0.5
-    coeffs_left = [4.7698603291927485e-06, 0.0005523684514175677, 0.025124707629480242, 0.5688673391241492, 16.13382387002397, 1464.9715537145275]
-    coeffs_right = [-9.267882571985216e-07, 4.954572425873791e-05, 0.0016201687947042655, -0.15277570672157192, 10.893237417742466, 1544.2819910395674]
-
-    if abs(force) <= deadband_eps:
-        pwm_pos_eps = np.polyval(coeffs_right, deadband_eps)
-        pwm_neg_eps = np.polyval(coeffs_left, -deadband_eps)
-        if force >= 0:
-            pwm = 1500 + (force / deadband_eps) * (pwm_pos_eps - 1500)
-        else:
-            pwm = 1500 + (force / deadband_eps) * (1500 - pwm_neg_eps)
-    elif force < -deadband_eps:
-        pwm = np.polyval(coeffs_left, force)
-    else:
-        pwm = np.polyval(coeffs_right, force)
-
-    return int(np.clip(pwm, 1100, 1900))
-
-def force_to_pwm_thruster8(force):
-    deadband_eps = 0.5
-    coeffs_left = [1.969990453701789e-05, 0.0018732855138689026, 0.0669614466686662, 1.1258357561487122, 18.729839818258526, 1465.5025109239948]
-    coeffs_right = [4.747498741718638e-06, -0.0005519151129485432, 0.0243819736986421, -0.5313334295643649, 13.750987401737758, 1533.5188424837772]
-
-    if abs(force) <= deadband_eps:
-        pwm_pos_eps = np.polyval(coeffs_right, deadband_eps)
-        pwm_neg_eps = np.polyval(coeffs_left, -deadband_eps)
-        if force >= 0:
-            pwm = 1500 + (force / deadband_eps) * (pwm_pos_eps - 1500)
-        else:
-            pwm = 1500 + (force / deadband_eps) * (1500 - pwm_neg_eps)
-    elif force < -deadband_eps:
-        pwm = np.polyval(coeffs_left, force)
-    else:
-        pwm = np.polyval(coeffs_right, force)
-
-    return int(np.clip(pwm, 1100, 1900))
+    Returns:
+        int: PWM signal for that specific thruster
+    """
+    coeffs_left, coeffs_right = thruster_poly_coeffs[thruster_index - 1]
+    return force_to_pwm(force, coeffs_left, coeffs_right)

--- a/catkin_ws/src/propulsion/src/thrust_mapper_utils.py
+++ b/catkin_ws/src/propulsion/src/thrust_mapper_utils.py
@@ -1,9 +1,6 @@
-SCALING_FACTOR = 0.5  # Tune based on observed thruster performance, in theory if 0 pwm should default to 1500
-MAX_FWD_FORCE = 4.52 * 9.81 * SCALING_FACTOR
-MAX_BKWD_FORCE = -3.52 * 9.81 * SCALING_FACTOR
+import numpy as np
 #Thrusters, like the Blue Robotics T200, don’t have a perfectly linear response near zero force.
 #Linear transition region around zero force (Newtons)
-DEADBAND_EPSILON = 1.5  #Tune based on thruster response
 #Creates a smooth transition around zero force to avoid abrupt changes in PWM.
 
 thruster_mount_dirs = [ #rep physical orientation of thrusters
@@ -19,61 +16,174 @@ thruster_mount_dirs = [ #rep physical orientation of thrusters
 #1 is forward, -1 is backward, 0.5 is half thrust in specific direction
 #If force is exactly zero, returns 1500 μs (neutral signal, no movement).
 
-def force_to_pwm(force):
-    """
-    Converts a force (N) to PWM (microseconds) with smooth zero transition
-    and aged thruster adjustments.
-    """
-    force = float(force)
-    force = min(max(force, MAX_BKWD_FORCE), MAX_FWD_FORCE)
+def force_to_pwm_thruster1(force):
+    '''Converts a desired thrust force (in Newtons) into a PWM signal (in microseconds)
+    for Thruster 1 using a two-sided 5th-order polynomial fit and linear smoothing 
+    in the deadband region. Coefficients of the polynomials for all 8 thrusters were made
+    to fit the the Thruster Test Data of May 2025. 
 
-    # Calculate linear transition boundaries
-    if abs(force) <= DEADBAND_EPSILON:
-        # Linear transition between positive and negative curves
+    - For forces above +0.5 N, a polynomial fit for positive forces is used.
+    - For forces below -0.5 N, a polynomial fit for negative forces is used.
+    - For small forces within ±0.5 N, the function linearly interpolates 
+      between 1500 µs and the polynomial curves to ensure smooth transitions 
+      and prevent jitter near zero thrust.
+    
+    The output PWM is clipped to remain within [1100, 1900] µs, which matches 
+    our ESC input limits.'''
+    
+    deadband_eps = 0.5
+    coeffs_left = [1.0230567551000761e-05, 0.00102996961393584, 0.040389999005431505, 0.7860223131995762, 16.77703700452621, 1458.4801287000814] 
+    coeffs_right = [3.430757828456944e-06, -0.0004931410796589675, 0.026547762979844677, -0.6681700673886003, 15.361505309013667, 1532.2050959044316]  
+
+    if abs(force) <= deadband_eps:
+        pwm_pos_eps = np.polyval(coeffs_right, deadband_eps)
+        pwm_neg_eps = np.polyval(coeffs_left, -deadband_eps)
         if force >= 0:
-            pwm_upper = positiveForceCurve(DEADBAND_EPSILON / 9.81)
-            pwm = 1500 + (force / DEADBAND_EPSILON) * (pwm_upper - 1500)
+            pwm = 1500 + (force / deadband_eps) * (pwm_pos_eps - 1500)
         else:
-            pwm_lower = negativeForceCurve(-DEADBAND_EPSILON / 9.81)
-            pwm = 1500 + (force / DEADBAND_EPSILON) * (1500 - pwm_lower)
+            pwm = 1500 + (force / deadband_eps) * (1500 - pwm_neg_eps)
+    elif force < -deadband_eps:
+        pwm = np.polyval(coeffs_left, force)
     else:
-        if force > 1e-4:
-            pwm = positiveForceCurve(force / 9.81)
-        elif force < -1e-4:
-            pwm = negativeForceCurve(force / 9.81)
+        pwm = np.polyval(coeffs_right, force)
+
+    return int(np.clip(pwm, 1100, 1900))
+
+def force_to_pwm_thruster2(force):
+    deadband_eps = 0.5
+    coeffs_left = [1.9792619863856807e-05, 0.00430568657152564, 0.16552600527321884, 2.005302506063938, 21.44799478063138, 1469.2876938929282]
+    coeffs_right = [2.7590747726334654e-06, -0.0004267788232113865, 0.023788005495560777, -0.6053581191075251, 15.257178074416181, 1537.8143209940818]
+
+    if abs(force) <= deadband_eps:
+        pwm_pos_eps = np.polyval(coeffs_right, deadband_eps)
+        pwm_neg_eps = np.polyval(coeffs_left, -deadband_eps)
+        if force >= 0:
+            pwm = 1500 + (force / deadband_eps) * (pwm_pos_eps - 1500)
         else:
-            pwm = 1500 #this is the default pwm,
+            pwm = 1500 + (force / deadband_eps) * (1500 - pwm_neg_eps)
+    elif force < -deadband_eps:
+        pwm = np.polyval(coeffs_left, force)
+    else:
+        pwm = np.polyval(coeffs_right, force)
 
-    # Ensure valid PWM range (typical ESC limits)
-    return int(min(max(pwm, 1200), 1800))#talk to jp about ESC limtis
-
-def negativeForceCurve(force):
-    """
-    Actual equations for converting a negative force (N) to a PWM (microseconds) for a T200 Thruster, got them from blue robotics documentation.
-    """
-    return (
-        1.4701043632380542 * (10**3)
-        + force * 2.3999978362959104 * (10**2)
-        + (force**2) * 2.5705773429064880 * (10**2)
-        + (force**3) * 3.1133962497995367 * (10**2)
-        + (force**4) * 2.1943237103469241 * (10**2)
-        + (force**5) * 8.4596303821198617 * (10**1)
-        + (force**6) * 1.6655229499580056 * (10**1)
-        + (force**7) * 1.3116834437073399
-    )
+    return int(np.clip(pwm, 1100, 1900))
 
 
-def positiveForceCurve(force):
-    """
-    Actual equations for converting a positive force (N) to a PWM (microseconds) for a T200 Thruster
-    """
-    return (
-        1.5299083405100268 * (10**3)
-        + force * 1.9317247519327023 * (10**2)
-        + (force**2) * -1.6227874418158476 * (10**2)
-        + (force**3) * 1.4980771349508325 * (10**2)
-        + (force**4) * -8.0478019175136623 * (10**1)
-        + (force**5) * 2.3661746039755371 * (10**1)
-        + (force**6) * -3.5559291204780612
-        + (force**7) * 2.1398707591286295 * (10**-1)
-    )
+def force_to_pwm_thruster3(force):
+    deadband_eps = 0.5
+    coeffs_left = [0.00015828221751606117, 0.01158034626673705, 0.29139761923839835, 2.9414234100262417, 23.829243182617976, 1462.4806630341138] 
+    coeffs_right =  [1.7707706911964165e-06, -0.00027076966193783096, 0.015275019271750026, -0.423532293350616, 13.60742808725115, 1537.3243900034613] 
+
+    if abs(force) <= deadband_eps:
+        pwm_pos_eps = np.polyval(coeffs_right, deadband_eps)
+        pwm_neg_eps = np.polyval(coeffs_left, -deadband_eps)
+        if force >= 0:
+            pwm = 1500 + (force / deadband_eps) * (pwm_pos_eps - 1500)
+        else:
+            pwm = 1500 + (force / deadband_eps) * (1500 - pwm_neg_eps)
+    elif force < -deadband_eps:
+        pwm = np.polyval(coeffs_left, force)
+    else:
+        pwm = np.polyval(coeffs_right, force)
+
+    return int(np.clip(pwm, 1100, 1900))
+
+
+def force_to_pwm_thruster4(force):
+    deadband_eps = 0.5
+    coeffs_left = [-1.1552965779022153e-05, 0.00038064670238558356, 0.06404572005694033, 1.6789593308233672, 26.85675098723853, 1489.744988765967] 
+    coeffs_right = [4.28729616014896e-06, -0.0005682519968556897, 0.02886925945271591, -0.7292412806746723, 17.22831131585594, 1532.5325493925116]
+
+    if abs(force) <= deadband_eps:
+        pwm_pos_eps = np.polyval(coeffs_right, deadband_eps)
+        pwm_neg_eps = np.polyval(coeffs_left, -deadband_eps)
+        if force >= 0:
+            pwm = 1500 + (force / deadband_eps) * (pwm_pos_eps - 1500)
+        else:
+            pwm = 1500 + (force / deadband_eps) * (1500 - pwm_neg_eps)
+    elif force < -deadband_eps:
+        pwm = np.polyval(coeffs_left, force)
+    else:
+        pwm = np.polyval(coeffs_right, force)
+
+    return int(np.clip(pwm, 1100, 1900))
+
+
+def force_to_pwm_thruster5(force):
+    deadband_eps = 0.5
+    coeffs_left = [-6.941580671470798e-06, -0.00058557986492076, -0.013961189254281707, -0.0002720187161500033, 12.236038684182764, 1448.4552329804822]
+    coeffs_right = [8.932847739553046e-07, -0.00019474823917039024, 0.013292476455512672, -0.39827137223089093, 13.002323887488586, 1535.342515302347]
+
+    if abs(force) <= deadband_eps:
+        pwm_pos_eps = np.polyval(coeffs_right, deadband_eps)
+        pwm_neg_eps = np.polyval(coeffs_left, -deadband_eps)
+        if force >= 0:
+            pwm = 1500 + (force / deadband_eps) * (pwm_pos_eps - 1500)
+        else:
+            pwm = 1500 + (force / deadband_eps) * (1500 - pwm_neg_eps)
+    elif force < -deadband_eps:
+        pwm = np.polyval(coeffs_left, force)
+    else:
+        pwm = np.polyval(coeffs_right, force)
+
+    return int(np.clip(pwm, 1100, 1900))
+
+
+
+def force_to_pwm_thruster6(force):
+    deadband_eps = 0.5
+    coeffs_left = [1.5816032862031332e-05, 0.0012422185608465996, 0.038226378488502424, 0.6168147468496009, 15.760260299367387, 1456.195377454675] 
+    coeffs_right = [2.7107832175712445e-06, -0.00037330147281785505, 0.019542179140516265, -0.4943442917222498, 14.201154149884227, 1534.225644742625]
+
+    if abs(force) <= deadband_eps:
+        pwm_pos_eps = np.polyval(coeffs_right, deadband_eps)
+        pwm_neg_eps = np.polyval(coeffs_left, -deadband_eps)
+        if force >= 0:
+            pwm = 1500 + (force / deadband_eps) * (pwm_pos_eps - 1500)
+        else:
+            pwm = 1500 + (force / deadband_eps) * (1500 - pwm_neg_eps)
+    elif force < -deadband_eps:
+        pwm = np.polyval(coeffs_left, force)
+    else:
+        pwm = np.polyval(coeffs_right, force)
+
+    return int(np.clip(pwm, 1100, 1900))
+
+
+def force_to_pwm_thruster7(force):
+    deadband_eps = 0.5
+    coeffs_left = [4.7698603291927485e-06, 0.0005523684514175677, 0.025124707629480242, 0.5688673391241492, 16.13382387002397, 1464.9715537145275]
+    coeffs_right = [-9.267882571985216e-07, 4.954572425873791e-05, 0.0016201687947042655, -0.15277570672157192, 10.893237417742466, 1544.2819910395674]
+
+    if abs(force) <= deadband_eps:
+        pwm_pos_eps = np.polyval(coeffs_right, deadband_eps)
+        pwm_neg_eps = np.polyval(coeffs_left, -deadband_eps)
+        if force >= 0:
+            pwm = 1500 + (force / deadband_eps) * (pwm_pos_eps - 1500)
+        else:
+            pwm = 1500 + (force / deadband_eps) * (1500 - pwm_neg_eps)
+    elif force < -deadband_eps:
+        pwm = np.polyval(coeffs_left, force)
+    else:
+        pwm = np.polyval(coeffs_right, force)
+
+    return int(np.clip(pwm, 1100, 1900))
+
+def force_to_pwm_thruster8(force):
+    deadband_eps = 0.5
+    coeffs_left = [1.969990453701789e-05, 0.0018732855138689026, 0.0669614466686662, 1.1258357561487122, 18.729839818258526, 1465.5025109239948]
+    coeffs_right = [4.747498741718638e-06, -0.0005519151129485432, 0.0243819736986421, -0.5313334295643649, 13.750987401737758, 1533.5188424837772]
+
+    if abs(force) <= deadband_eps:
+        pwm_pos_eps = np.polyval(coeffs_right, deadband_eps)
+        pwm_neg_eps = np.polyval(coeffs_left, -deadband_eps)
+        if force >= 0:
+            pwm = 1500 + (force / deadband_eps) * (pwm_pos_eps - 1500)
+        else:
+            pwm = 1500 + (force / deadband_eps) * (1500 - pwm_neg_eps)
+    elif force < -deadband_eps:
+        pwm = np.polyval(coeffs_left, force)
+    else:
+        pwm = np.polyval(coeffs_right, force)
+
+    return int(np.clip(pwm, 1100, 1900))


### PR DESCRIPTION
This PR introduces a complete refactor of the thruster_mapper and thruster_mapper_utils modules to integrate per-thruster force-to-PWM conversion functions, based on real-world test data collected in May 2025.

Changes:
Replaced the single force_to_pwm() function with dedicated polynomial-based mappings for each of the 8 thrusters (force_to_pwm_thruster1 to force_to_pwm_thruster8).

Each function uses a two-sided 5th order polynomial fit, customized per thruster using measured thrust vs. PWM data.

Added linear smoothing in the deadband region (±0.5 N) to reduce jitter near neutral.

Updated thruster_mapper.py to:

Call the appropriate function per thruster