### PR TITLE
Update sim build

### DIFF
--- a/Docker/base/Dockerfile
+++ b/Docker/base/Dockerfile
@@ -9,9 +9,8 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en     
 
 # Install all needed deps and compile the mesa llvmpipe driver from source.
+# Delete previous GPG key retrieval
 RUN apt-get update && apt-get install -y wget \
-    && sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list' \
-    && wget http://packages.ros.org/ros.key -O - | apt-key add - \
     && apt-get update \
     && apt-get install -y python3-catkin-tools python3-pip python-is-python3 kmod kbd tmux vim iputils-ping iproute2 \
     && apt-get install -y --no-install-recommends \

--- a/Docker/sim/Dockerfile
+++ b/Docker/sim/Dockerfile
@@ -1,5 +1,17 @@
 FROM mcgillrobotics/auv_2025:base
 
+# Fix GPG key errors from foxglove installation
+RUN sudo rm /etc/apt/sources.list.d/ros-latest.list && sudo rm /etc/apt/sources.list.d/ros1-latest.list
+RUN sudo apt update
+RUN sudo apt install -y curl gnupg2 lsb-release
+RUN echo "deb [signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/ros1-latest.list
+RUN sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+RUN sudo apt update
+RUN sudo apt install -y software-properties-common
+RUN sudo add-apt-repository universe
+RUN sudo apt update
+#
+
 RUN sudo apt-get update && sudo apt-get install -y ros-noetic-foxglove-bridge
 
 RUN pip3 install --no-cache-dir numpy-quaternion ultralytics \


### PR DESCRIPTION
## Related Issue(s)
  - Unable to build the sim Docker image due to expired GPG key for the ROS package repository (http://packages.ros.org/ros/ubuntu).
  - During build, received the error: `W: GPG error: http://packages.ros.org/ros/ubuntu focal InRelease: The following signatures were invalid: EXPKEYSIG F42ED6FBAB17C654 Open Robotics <info@osrfoundation.org> 
 E: The repository 'http://packages.ros.org/ros/ubuntu focal InRelease' is not signed.`
- Caused failure when trying to install ros-noetic-foxglove-bridge package inside Docker.
- Additional warnings about duplicate entries in /etc/apt/sources.list.d/ros-latest.list and /etc/apt/sources.list.d/ros1-latest.list.

## Changes Made
- Removed the conflicting and duplicate ROS apt source list files (ros-latest.list and ros1-latest.list) to eliminate duplicate repository warnings
- Installed necessary tools (curl, gnupg2, lsb-release, software-properties-common) to manage repositories and keys properly
- Re-added the ROS repository source list with the updated GPG key using the signed-by option, pointing to the newly downloaded ros-archive-keyring.gpg
- Downloaded the updated and valid ROS GPG key directly from the official ROS distro GitHub repository to replace the expired key causing installation errors
- Enabled the Ubuntu universe repository to ensure package dependencies can be resolved
- Ran multiple apt update commands throughout to refresh package lists after each change
- These steps resolved GPG signature verification errors and allowed successful installation of the ros-noetic-foxglove-bridge package during the Docker build process.

## Rationale/Other Solutions Considered
- Issue caused by ROS GPG key expiration on June 1, 2025
